### PR TITLE
docs: plan.md に正式版開発前の未決事項セクションを追加

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -80,7 +80,7 @@ paste イベント (iframe contentDocument)
 ファイル構成図では「変更なし」と記載したが、正式版では以下の変更が必要：
 
 - コードブロック抑止ロジックの追加（①の実装）
-- `hasNotation()` 更新に伴う条件分岐の修正（後述 §未決事項-1 参照）
+- `hasNotation()` 更新に伴う条件分岐の修正（後述『未決事項・要確認 > 1. hasNotation() ...』参照）
 - `text` セグメントを `pasteHandler` ではなく `line-parser` に渡す処理
 - 新セグメント型（`more`, `button`, `reuse`, `shortcode`, `generic-block`, `paragraph`）のハンドリング
 


### PR DESCRIPTION
- hasNotation() の更新戦略（全記法への拡張 or 廃止 or 2段構造）
- paste-handler.js の変更範囲の矛盾を注記として明記
- ショートコード正規表現と Markdown リンクの衝突問題
- {block:} 属性値の型変換ルール未定義
- ::: 記法の拡張性方針
- ブロック不存在時のフォールバック動作
- 複数行ショートコードのスコープ確認
- 自動テストの有無

https://claude.ai/code/session_01EdpxY6X7WFo4pfCa2FUjP8