### PR TITLE
claude/fix-button-conversion-nested-ehdPx

### DIFF
--- a/src/line-parser.js
+++ b/src/line-parser.js
@@ -16,7 +16,8 @@ const REUSE_REGEX = /^\{\{reuse:([\w-]+)\}\}[ \t\r]*$/m;
  * Returns an array of segments:
  *   { type: 'text',   content: string }
  *   { type: 'button', url: string, label: string, className: string }
- *   { type: 'reuse',  id: number|null }
+ *   { type: 'reuse',  id: number }  — only emitted when id is resolvable (> 0);
+ *                                     unresolvable reuse lines are treated as text
  *
  * Lines that do not match any notation are accumulated in a buffer and
  * flushed as a 'text' segment when a match is found or at the end.
@@ -66,7 +67,11 @@ export function parseLineSegments( text, shorthandMap = {}, reuseShorthandMap = 
 					numericId = mapped;
 				}
 			}
-			result.push( { type: 'reuse', id: numericId, raw: line } );
+			if ( numericId !== null && numericId > 0 ) {
+				result.push( { type: 'reuse', id: numericId } );
+			} else {
+				buffer.push( line );
+			}
 			continue;
 		}
 

--- a/src/line-parser.js
+++ b/src/line-parser.js
@@ -66,7 +66,7 @@ export function parseLineSegments( text, shorthandMap = {}, reuseShorthandMap = 
 					numericId = mapped;
 				}
 			}
-			result.push( { type: 'reuse', id: numericId } );
+			result.push( { type: 'reuse', id: numericId, raw: line } );
 			continue;
 		}
 

--- a/src/line-parser.js
+++ b/src/line-parser.js
@@ -56,7 +56,6 @@ export function parseLineSegments( text, shorthandMap = {}, reuseShorthandMap = 
 
 		const reuseMatch = REUSE_REGEX.exec( line );
 		if ( reuseMatch ) {
-			flushBuffer();
 			const idOrAlias = reuseMatch[ 1 ];
 			let numericId = null;
 			if ( /^\d+$/.test( idOrAlias ) ) {
@@ -68,8 +67,10 @@ export function parseLineSegments( text, shorthandMap = {}, reuseShorthandMap = 
 				}
 			}
 			if ( numericId !== null && numericId > 0 ) {
+				flushBuffer();
 				result.push( { type: 'reuse', id: numericId } );
 			} else {
+				// Unresolvable alias/ID — keep in buffer as plain text
 				buffer.push( line );
 			}
 			continue;

--- a/src/paste-handler.js
+++ b/src/paste-handler.js
@@ -132,12 +132,26 @@ function embedSegmentToBlock( segment ) {
  * @return {Array} Gutenberg blocks
  */
 function innerSegmentsToBlocks( innerSegments ) {
+	// Expand text segments to detect button and reuse notation line-by-line,
+	// mirroring the same flatMap applied to top-level segments in onPaste().
+	const expandedSegments = innerSegments.flatMap( ( inner ) =>
+		inner.type === 'text'
+			? parseLineSegments( inner.content, buttonShorthandMap, reuseShorthandMap )
+			: [ inner ]
+	);
+
 	const blocks = [];
-	for ( const inner of innerSegments ) {
+	for ( const inner of expandedSegments ) {
 		if ( inner.type === 'image' ) {
 			blocks.push( imageSegmentToBlock( inner ) );
 		} else if ( inner.type === 'embed' ) {
 			blocks.push( embedSegmentToBlock( inner ) );
+		} else if ( inner.type === 'button' ) {
+			blocks.push( buttonsSegmentToBlock( inner ) );
+		} else if ( inner.type === 'reuse' ) {
+			if ( inner.id !== null && inner.id > 0 ) {
+				blocks.push( createBlock( 'core/block', { ref: inner.id } ) );
+			}
 		} else if ( inner.content.trim() ) {
 			const converted = pasteHandler( {
 				plainText: inner.content,

--- a/src/paste-handler.js
+++ b/src/paste-handler.js
@@ -127,8 +127,10 @@ function embedSegmentToBlock( segment ) {
 
 /**
  * Convert an array of inner segments (from notation-parser) into blocks.
+ * Text segments are first expanded via parseLineSegments() so that button
+ * and reuse notation nested inside callout/media-text blocks is handled.
  *
- * @param {Array} innerSegments  Parsed segments (image, embed, or text)
+ * @param {Array} innerSegments  Parsed segments (image, embed, text, button, or reuse)
  * @return {Array} Gutenberg blocks
  */
 function innerSegmentsToBlocks( innerSegments ) {
@@ -149,7 +151,7 @@ function innerSegmentsToBlocks( innerSegments ) {
 		} else if ( inner.type === 'button' ) {
 			blocks.push( buttonsSegmentToBlock( inner ) );
 		} else if ( inner.type === 'reuse' ) {
-			if ( inner.id !== null && inner.id > 0 ) {
+			if ( inner.id > 0 ) {
 				blocks.push( createBlock( 'core/block', { ref: inner.id } ) );
 			}
 		} else if ( inner.content.trim() ) {
@@ -274,7 +276,7 @@ function onPaste( event ) {
 				createBlock( 'core/media-text', mediaAttrs, innerBlocks )
 			);
 		} else if ( segment.type === 'reuse' ) {
-			if ( segment.id !== null && segment.id > 0 ) {
+			if ( segment.id > 0 ) {
 				allBlocks.push( createBlock( 'core/block', { ref: segment.id } ) );
 			}
 		} else if ( segment.content.trim() ) {

--- a/src/paste-handler.js
+++ b/src/paste-handler.js
@@ -151,11 +151,6 @@ function innerSegmentsToBlocks( innerSegments ) {
 		} else if ( inner.type === 'reuse' ) {
 			if ( inner.id !== null && inner.id > 0 ) {
 				blocks.push( createBlock( 'core/block', { ref: inner.id } ) );
-			} else if ( inner.raw ) {
-				const converted = pasteHandler( { plainText: inner.raw, mode: 'BLOCKS' } );
-				if ( Array.isArray( converted ) ) {
-					blocks.push( ...converted );
-				}
 			}
 		} else if ( inner.content.trim() ) {
 			const converted = pasteHandler( {
@@ -281,11 +276,6 @@ function onPaste( event ) {
 		} else if ( segment.type === 'reuse' ) {
 			if ( segment.id !== null && segment.id > 0 ) {
 				allBlocks.push( createBlock( 'core/block', { ref: segment.id } ) );
-			} else if ( segment.raw ) {
-				const converted = pasteHandler( { plainText: segment.raw, mode: 'BLOCKS' } );
-				if ( Array.isArray( converted ) ) {
-					allBlocks.push( ...converted );
-				}
 			}
 		} else if ( segment.content.trim() ) {
 			const normalBlocks = pasteHandler( {

--- a/src/paste-handler.js
+++ b/src/paste-handler.js
@@ -151,6 +151,11 @@ function innerSegmentsToBlocks( innerSegments ) {
 		} else if ( inner.type === 'reuse' ) {
 			if ( inner.id !== null && inner.id > 0 ) {
 				blocks.push( createBlock( 'core/block', { ref: inner.id } ) );
+			} else if ( inner.raw ) {
+				const converted = pasteHandler( { plainText: inner.raw, mode: 'BLOCKS' } );
+				if ( Array.isArray( converted ) ) {
+					blocks.push( ...converted );
+				}
 			}
 		} else if ( inner.content.trim() ) {
 			const converted = pasteHandler( {
@@ -276,6 +281,11 @@ function onPaste( event ) {
 		} else if ( segment.type === 'reuse' ) {
 			if ( segment.id !== null && segment.id > 0 ) {
 				allBlocks.push( createBlock( 'core/block', { ref: segment.id } ) );
+			} else if ( segment.raw ) {
+				const converted = pasteHandler( { plainText: segment.raw, mode: 'BLOCKS' } );
+				if ( Array.isArray( converted ) ) {
+					allBlocks.push( ...converted );
+				}
 			}
 		} else if ( segment.content.trim() ) {
 			const normalBlocks = pasteHandler( {


### PR DESCRIPTION
innerSegmentsToBlocks() でテキストセグメントを parseLineSegments() で
展開するよう修正。これにより :::info や :::media-text ブロック内の
[btn] 記法がボタンブロックへ正しく変換される。

reuse 記法（{{reuse:ID}}）の内部ブロックへの対応も同様に追加。

https://claude.ai/code/session_01WdBuihos1RcNRSscoFpw1P